### PR TITLE
Use direct links, not footnote links

### DIFF
--- a/templates/relnotes.md
+++ b/templates/relnotes.md
@@ -62,7 +62,3 @@ UNSORTED
 **other**
 {{unsorted}}
 
-{{links}}
-{{cargo_links}}
-
-


### PR DESCRIPTION
This makes it easier to curate and prune the generated list of merged
PRs, without having to keep a separate list of links in sync.

The release notes still remain readable with this change; the links
aren't long, and the rendered version looks identical.
