### PR TITLE
Reword "Internal Changes" to not say "no direct user facing benefits"

### DIFF
--- a/templates/relnotes.md
+++ b/templates/relnotes.md
@@ -50,9 +50,9 @@ Compatibility Notes
 Internal Changes
 ----------------
 
-These changes provide no direct user facing benefits, but represent significant
-improvements to the internals and overall performance of rustc
-and related tools.
+These changes do not affect any public interfaces of Rust, but they represent
+significant improvements to the performance or internals of rustc and related
+tools.
 
 UNSORTED
 --------


### PR DESCRIPTION
The "Internal Changes" section currently says "no direct user facing
benefits", but includes "significant improvements to the ... overall
performance", which is a user-facing benefit. Reword it to say "do not
affect any public interfaces" instead.
