### PR TITLE
Add version-stable anchors to the release notes template.

### DIFF
--- a/templates/relnotes.md
+++ b/templates/relnotes.md
@@ -1,6 +1,8 @@
 Version {{version}} ({{date}})
 ==========================
 
+<a id="{{version}}-Language"></a>
+
 Language
 --------
 **relnotes**
@@ -8,6 +10,8 @@ Language
 
 **other**
 {{language_unsorted}}
+
+<a id="{{version}}-Compiler"></a>
 
 Compiler
 --------
@@ -17,6 +21,8 @@ Compiler
 **other**
 {{compiler_unsorted}}
 
+<a id="{{version}}-Libraries"></a>
+
 Libraries
 ---------
 **relnotes**
@@ -25,8 +31,12 @@ Libraries
 **other**
 {{libraries_unsorted}}
 
+<a id="{{version}}-Stabilized-APIs"></a>
+
 Stabilized APIs
 ---------------
+
+<a id="{{version}}-Cargo"></a>
 
 Cargo
 -----
@@ -36,8 +46,12 @@ Cargo
 **other**
 {{cargo_unsorted}}
 
+<a id="{{version}}-Misc"></a>
+
 Misc
 ----
+
+<a id="{{version}}-Compatibility-Notes"></a>
 
 Compatibility Notes
 -------------------
@@ -46,6 +60,8 @@ Compatibility Notes
 
 **other**
 {{compat_unsorted}}
+
+<a id="{{version}}-Internal-Changes"></a>
 
 Internal Changes
 ----------------


### PR DESCRIPTION
Add version-stable anchors to the release notes template.

The current template embeds anchors from subheadings like "Compiler" that have the same section subheading name; thus, the generated html ends up with `id` attributes that have been uniquified (by adding a incremented suffix, e.g. `#compiler-2`) but those `id` attributes will change (e.g. to `#compiler-3`) as new releases come out.

The change in this PR enables one to write urls that end with e.g. `#1.66.0-Compiler` and have that url remain usable (in terms of pointing to the compiler subsection *for that release*), even in face of future releases.

FYI: in my local experimentation, it appears that in the context of hackmd, visiting an anchor tag with no contents will end up scrolling to a point where the hackmd toolbar obscures the subsection heading. This is unfortunate (though still an improvement on the current state of affairs where one has *no option* to link directly to these subsections in a version-stable manner). I am hoping that there is not a similar problem for the RELEASES.md file when viewed on github itself.