### PR TITLE
Add basic error handling to GraphQL query

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -163,14 +163,19 @@ fn get_issues_by_milestone(version: &str, repo_name: &'static str) -> Vec<json::
 
         let client = Client::new();
 
-        let json = client
+        let response = client
             .post("https://api.github.com/graphql")
             .headers(headers.clone())
             .body(json_query)
             .send()
-            .unwrap()
+            .unwrap();
+        let status = response.status();
+        let json = response
             .json::<json::Value>()
             .unwrap();
+        if !status.is_success() {
+            panic!("API Error {}: {}", status, json);
+        }
 
         let milestones_data = json["data"]["repository"]["milestones"].clone();
         assert_eq!(


### PR DESCRIPTION
Fixes #123

When I use a fine-grained token now, I get:

```
thread 'main' panicked at 'API Error 401 Unauthorized: {"documentation_url":"https://docs.github.com/graphql/guides/forming-calls-with-graphql#authenticating-with-graphql","message":"Personal access tokens with fine grained access do not support the GraphQL API"}', src/main.rs:177:13
```