### PR TITLE
chore: remove deprecated action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,12 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.channel }}
-      - uses: rust-lang/simpleinfra/github-actions/simple-ci@master
+      - name: Build
+        run: cargo build --tests --workspace
+      - name: Test
+        run: cargo test --workspace
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
Hi, I'm Marco from the Rust Infra team 👋

As described in https://github.com/rust-lang/simpleinfra/issues/445 we want to delete the `simple-ci` GitHub action.

This PR substitutes the action with the equivalent commands 👍

Let me know if you have any questions 🙏
