### PR TITLE
misc stuff

### DIFF
--- a/templates/relnotes.md
+++ b/templates/relnotes.md
@@ -24,11 +24,23 @@ Libraries
 Stabilized APIs
 ---------------
 
+{{stabilized_apis_relnotes}}
+
+These APIs are now stable in const contexts:
+
+{{const_stabilized_apis_relnotes}}
+
 <a id="{{version}}-Cargo"></a>
 
 Cargo
 -----
 {{cargo_relnotes}}
+
+<a id="{{version}}-Rustdoc"></a>
+
+Rustdoc
+-----
+{{rustdoc_relnotes}}
 
 <a id="{{version}}-Compatibility-Notes"></a>
 
@@ -46,3 +58,9 @@ significant improvements to the performance or internals of rustc and related
 tools.
 
 {{internal_changes_relnotes}}
+
+
+Other
+-----
+
+{{other_relnotes}}


### PR DESCRIPTION
Support `Stabilized APIs`/`Const Stabilized APIs` and `Rustdoc` so that its easier to edit original tracking issues and re-generate the resulting relnotes
Consider `Libraries` header instead of `Library` so that it is more consistent with what the actual template uses
Newtype instead of having a giant tuple of strings because it was scary changing stuff xd
Delete `_unsorted` dead code, I don't know if it would just be better to actually incorporate this in the output somehow? The history is always here in git though and all the warnings were a bit offputting lol